### PR TITLE
fix warning: Module names should be written in PascalCase. [R:1]

### DIFF
--- a/lib/pillar/migrations/generator.ex
+++ b/lib/pillar/migrations/generator.ex
@@ -5,7 +5,7 @@ defmodule Pillar.Migrations.Generator do
 
   def migration_template(name) do
     """
-    defmodule Pillar.Migrations.#{String.capitalize(name)} do
+    defmodule Pillar.Migrations.#{Macro.camelize(name)} do
       def up do
         "CREATE TABLE example (field FixedString(10)) ENGINE = Memory"
       end


### PR DESCRIPTION
fix warning: Module names should be written in PascalCase. [R:1]