### PR TITLE
Add missing conversion function for DateTime64(3)

### DIFF
--- a/lib/pillar/type_convert/to_elixir.ex
+++ b/lib/pillar/type_convert/to_elixir.ex
@@ -48,6 +48,8 @@ defmodule Pillar.TypeConvert.ToElixir do
     nil
   end
 
+  def convert("DateTime64(3)", value), do: convert("DateTime", value)
+
   def convert("DateTime", value) do
     {:ok, datetime, _offset} = DateTime.from_iso8601(value <> "Z")
     datetime


### PR DESCRIPTION
Conversion of Clickhouse type DateTime64(3) is currently not implemented in Pillar. This pull requests adds a convert function to to_elixir.ex for DateTime64(3).