### PR TITLE
Map type support prototype

### DIFF
--- a/lib/pillar/type_convert/to_clickhouse.ex
+++ b/lib/pillar/type_convert/to_clickhouse.ex
@@ -44,8 +44,13 @@ defmodule Pillar.TypeConvert.ToClickhouse do
   end
 
   def convert(param) when is_map(param) do
-    json = Jason.encode!(param)
-    convert(json)
+    encoded =
+      param
+      |> Enum.to_list()
+      |> Enum.map(fn {k, v} -> "#{convert(k)}, #{convert(v)}" end)
+      |> Enum.join(",")
+
+    "map(" <> encoded <> ")" # TODO: check if IO lists would be more efficient for larger maps
   end
 
   def convert({a, b, c, d} = ip)

--- a/lib/pillar/type_convert/to_elixir.ex
+++ b/lib/pillar/type_convert/to_elixir.ex
@@ -48,7 +48,7 @@ defmodule Pillar.TypeConvert.ToElixir do
     nil
   end
 
-  def convert("DateTime64(3)", value), do: convert("DateTime", value)
+  def convert("DateTime64" <> _precision_and_zone, value), do: convert("DateTime", value)
 
   def convert("DateTime", value) do
     {:ok, datetime, _offset} = DateTime.from_iso8601(value <> "Z")
@@ -100,6 +100,10 @@ defmodule Pillar.TypeConvert.ToElixir do
   end
 
   def convert("Decimal" <> _decimal_subtypes, value) do
+    value
+  end
+
+  def convert("Map" <> _subtypes, value) do
     value
   end
 end

--- a/test/pillar/type_convert/to_clickhouse_test.exs
+++ b/test/pillar/type_convert/to_clickhouse_test.exs
@@ -33,7 +33,8 @@ defmodule Pillar.TypeConvert.ToClickhouseTest do
     end
 
     test "Map" do
-      assert ToClickhouse.convert(%{key: "value"}) == ~S('{"key":"value"}')
+      assert ToClickhouse.convert(%{key: "value"}) == "map('key', 'value')"
+      assert ToClickhouse.convert(%{key: "val'ue", k2: "v2"}) == "{'key':'val''ue','k2':'v2'}"
     end
 
     test "Bool" do
@@ -55,7 +56,8 @@ defmodule Pillar.TypeConvert.ToClickhouseTest do
                %{"key" => "value"},
                ~U[2020-03-26 22:26:14.286832Z],
                "Le'Blank"
-             ]) == ~S([1,2,1,0,'1970-01-01','{"key":"value"}','2020-03-26T22:26:14','Le''Blank'])
+             ]) ==
+               ~S/[1,2,1,0,'1970-01-01',map('key', 'value'),'2020-03-26T22:26:14','Le''Blank']/
 
       # array with array
       assert ToClickhouse.convert([


### PR DESCRIPTION
Here is a prototype with some ideas on how to handle maps.

`ToElixir` is straight forward - just keep the map.
(I also added a small change to DateTime64, because I needed that fixed as well - please take a look)

For `ToClickhouse` I initially checked the approach you mentioned in #32 with the `{:map, {:key_type, :value_type, ...` prefix tuple. This would have worked as well, but implementing all the conversion functions for the different sub types (of which not all CH types are supported in CH maps - especially for keys) would be a lot of code (only for maps).

So, for now i'm only creating a map in `ToClickhouse` as `map(k:v,k:v,...)` string, using the existing `convert()` functions to handle the keys and values. This means, that the user needs to make sure that they are using the correct types in their elixir maps.
So, if a user want's to insert into a `Map(String, String)`, they need to make sure, that their elixir maps contain strings (or something that get's serialized to string).

What do you think?

ps: I wasn't sure about what `ToClickhouseJson` does exactly. So maybe, the changes from `ToClickhouse` need to be ported to there as well - not sure.