### PR TITLE
Date32 convert support

### DIFF
--- a/lib/pillar/type_convert/to_elixir.ex
+++ b/lib/pillar/type_convert/to_elixir.ex
@@ -89,6 +89,10 @@ defmodule Pillar.TypeConvert.ToElixir do
     Date.from_iso8601!(value)
   end
 
+  def convert("Date32", value) do
+    Date.from_iso8601!(value)
+  end
+
   def convert("IPv4", value) do
     value
   end

--- a/test/pillar_test.exs
+++ b/test/pillar_test.exs
@@ -261,21 +261,31 @@ defmodule PillarTest do
     end
 
     test "Date32 test", %{conn: conn} do
-      table_name = "date32_test_#{@timestamp}"
+      sql = "SELECT toDate32(now()) AS Date32"
 
-      create_table_sql = """
-      CREATE TABLE IF NOT EXISTS #{table_name} (field Date32) ENGINE = Memory
-      """
+      case Pillar.select(conn, sql) do
+        {:error, %Pillar.HttpClient.Response{body: error}} ->
+          assert error =~ ~r/Unknown function toDate32/
 
-      assert {:ok, ""} = Pillar.query(conn, create_table_sql)
+        {:ok, [%{"Date32" => date32_result}]} ->
+          assert %Date{} = date32_result
 
-      assert {:ok, ""} =
-               Pillar.query(conn, "INSERT INTO #{table_name} SELECT {date}", %{
-                 date: Date.utc_today()
-               })
+          table_name = "date32_test_#{@timestamp}"
 
-      assert {:ok, [%{"field" => %Date{}}]} =
-               Pillar.select(conn, "SELECT * FROM #{table_name} LIMIT 1")
+          create_table_sql = """
+          CREATE TABLE IF NOT EXISTS #{table_name} (field Date32) ENGINE = Memory
+          """
+
+          assert {:ok, ""} = Pillar.query(conn, create_table_sql)
+
+          assert {:ok, ""} =
+                   Pillar.query(conn, "INSERT INTO #{table_name} SELECT {date}", %{
+                     date: Date.utc_today()
+                   })
+
+          assert {:ok, [%{"field" => %Date{}}]} =
+                   Pillar.select(conn, "SELECT * FROM #{table_name} LIMIT 1")
+      end
     end
 
     test "DateTime test", %{conn: conn} do

--- a/test/pillar_test.exs
+++ b/test/pillar_test.exs
@@ -260,6 +260,24 @@ defmodule PillarTest do
                Pillar.query(conn, "SELECT * FROM #{table_name} LIMIT 1 FORMAT JSON")
     end
 
+    test "Date32 test", %{conn: conn} do
+      table_name = "date32_test_#{@timestamp}"
+
+      create_table_sql = """
+      CREATE TABLE IF NOT EXISTS #{table_name} (field Date32) ENGINE = Memory
+      """
+
+      assert {:ok, ""} = Pillar.query(conn, create_table_sql)
+
+      assert {:ok, ""} =
+               Pillar.query(conn, "INSERT INTO #{table_name} SELECT {date}", %{
+                 date: Date.utc_today()
+               })
+
+      assert {:ok, [%{"field" => %Date{}}]} =
+               Pillar.select(conn, "SELECT * FROM #{table_name} LIMIT 1")
+    end
+
     test "DateTime test", %{conn: conn} do
       sql = "SELECT now()"
 


### PR DESCRIPTION
A date [Date32](https://clickhouse.com/docs/en/sql-reference/data-types/date32/). Stored in four bytes as the number of days since 1925-01-01. Allows storing values till 2283-11-11.