### PR TITLE
add option db_side_batch_insertions

### DIFF
--- a/lib/pillar.ex
+++ b/lib/pillar.ex
@@ -10,36 +10,30 @@ defmodule Pillar do
 
   def insert(%Connection{} = connection, query, params \\ %{}, options \\ %{}) do
     final_sql = QueryBuilder.query(query, params)
-    timeout = Map.get(options, :timeout, @default_timeout_ms)
-
-    execute_sql(connection, final_sql, timeout)
+    execute_sql(connection, final_sql, options)
   end
 
   def insert_to_table(%Connection{} = connection, table_name, record_or_records, options \\ %{})
       when is_binary(table_name) do
     final_sql = QueryBuilder.insert_to_table(table_name, record_or_records)
-    timeout = Map.get(options, :timeout, @default_timeout_ms)
-
-    execute_sql(connection, final_sql, timeout)
+    execute_sql(connection, final_sql, options)
   end
 
   def query(%Connection{} = connection, query, params \\ %{}, options \\ %{}) do
     final_sql = QueryBuilder.query(query, params)
-    timeout = Map.get(options, :timeout, @default_timeout_ms)
-
-    execute_sql(connection, final_sql, timeout)
+    execute_sql(connection, final_sql, options)
   end
 
   def select(%Connection{} = connection, query, params \\ %{}, options \\ %{}) do
     final_sql = QueryBuilder.query(query, params) <> "\n FORMAT JSON"
-    timeout = Map.get(options, :timeout, @default_timeout_ms)
-
-    execute_sql(connection, final_sql, timeout)
+    execute_sql(connection, final_sql, options)
   end
 
-  defp execute_sql(connection, final_sql, timeout) do
+  defp execute_sql(connection, final_sql, options) do
+    timeout = Map.get(options, :timeout, @default_timeout_ms)
+
     connection
-    |> Connection.url_from_connection()
+    |> Connection.url_from_connection(options)
     |> HttpClient.post(final_sql, timeout: timeout)
     |> ResponseParser.parse()
   end

--- a/lib/pillar/connection.ex
+++ b/lib/pillar/connection.ex
@@ -60,7 +60,7 @@ defmodule Pillar.Connection do
     }
   end
 
-  def url_from_connection(%__MODULE__{} = connect_config) do
+  def url_from_connection(%__MODULE__{} = connect_config, options \\ %{}) do
     params =
       reject_nils(%{
         password: connect_config.password,
@@ -70,6 +70,12 @@ defmodule Pillar.Connection do
         allow_suspicious_low_cardinality_types:
           @boolean_to_clickhouse[connect_config.allow_suspicious_low_cardinality_types]
       })
+
+    params =
+      case Map.fetch(options, :db_side_batch_insertions) do
+        {:ok, true} -> Map.put(params, "async_insert", 1)
+        _ -> params
+      end
 
     uri_struct = %URI{
       host: connect_config.host,

--- a/test/pillar/connection_test.exs
+++ b/test/pillar/connection_test.exs
@@ -52,5 +52,29 @@ defmodule Pillar.ConnectionTest do
 
       assert Connection.url_from_connection(connection) == "https://localhost:8123/?"
     end
+
+    test "build valid url with db_side_batch_insertions" do
+      connection = %Connection{
+        database: "default",
+        host: "localhost",
+        scheme: "https",
+        user: "user",
+        password: "password",
+        port: 8123
+      }
+
+      assert Connection.url_from_connection(connection) ==
+               "https://localhost:8123/?database=default&password=password&user=user"
+
+      options = %{db_side_batch_insertions: true}
+
+      assert Connection.url_from_connection(connection, options) ==
+               "https://localhost:8123/?database=default&password=password&user=user&async_insert=1"
+
+      options = %{db_side_batch_insertions: false}
+
+      assert Connection.url_from_connection(connection, options) ==
+               "https://localhost:8123/?database=default&password=password&user=user"
+    end
   end
 end


### PR DESCRIPTION
Hi. We need to use this option https://clickhouse.com/docs/en/operations/settings/settings/#async-insert in our project. However, Pillar doesn't support it. So I've made this small change.

Unfortunately, this is not an ideal solution. I believe it would be better to use it like this:
```
defmodule ClickhouseMaster do
  use Pillar,
    connection_strings: [...],
    ...
    db_side_batch_insertions: true
end
```
but it is not so easy to pass it through to Pillar.Pool.Worker state as it accepts only a connection_strings. Fixing this will take too much changes in code. So I've just put it into Application environment. Let's discuss it.

There is also a naming issue. As you can see ClickHouse option is called **async_insert**. Which conflicts with **async_insert_** functions of Pillar. So I name the the option **db_side_batch_insertions**. Let's discuss that too.