### PR TITLE
FIX: Tuple parsing for elixir

### DIFF
--- a/lib/pillar/type_convert/to_elixir.ex
+++ b/lib/pillar/type_convert/to_elixir.ex
@@ -153,15 +153,10 @@ defmodule Pillar.TypeConvert.ToElixir do
       |> String.trim_trailing(")")
       |> String.split([", "])
 
-    Enum.reduce(Enum.zip(key_types, values), [], fn
-      {key_type, {_key, value}}, acc ->
-        [_key, type] = String.split(key_type)
-        [convert(type, value) | acc]
-
-      {key_type, value}, acc ->
-        [convert(key_type, value) | acc]
+    Enum.zip(key_types, values)
+    |> Enum.map(fn {key_type, value} ->
+      convert(key_type, value)
     end)
-    |> Enum.reverse()
   end
 
   defp convert_datetime_with_timezone(value, time_zone) do

--- a/lib/pillar/type_convert/to_elixir.ex
+++ b/lib/pillar/type_convert/to_elixir.ex
@@ -153,10 +153,15 @@ defmodule Pillar.TypeConvert.ToElixir do
       |> String.trim_trailing(")")
       |> String.split([", "])
 
-    Enum.reduce(Enum.zip(key_types, values), %{}, fn {key_type, {_key, value}}, acc ->
-      [key, type] = String.split(key_type)
-      Map.put(acc, key, convert(type, value))
+    Enum.reduce(Enum.zip(key_types, values), [], fn
+      {key_type, {_key, value}}, acc ->
+        [_key, type] = String.split(key_type)
+        [convert(type, value) | acc]
+
+      {key_type, value}, acc ->
+        [convert(key_type, value) | acc]
     end)
+    |> Enum.reverse()
   end
 
   defp convert_datetime_with_timezone(value, time_zone) do

--- a/lib/pillar/type_convert/to_elixir.ex
+++ b/lib/pillar/type_convert/to_elixir.ex
@@ -154,8 +154,13 @@ defmodule Pillar.TypeConvert.ToElixir do
       |> String.split([", "])
 
     Enum.zip(key_types, values)
-    |> Enum.map(fn {key_type, value} ->
-      convert(key_type, value)
+    |> Enum.map(fn
+      {key_type, {_key, value}} ->
+        [_key, type] = String.split(key_type)
+        convert(type, value)
+
+      {key_type, value} ->
+        convert(key_type, value)
     end)
   end
 

--- a/lib/pillar/type_convert/to_elixir.ex
+++ b/lib/pillar/type_convert/to_elixir.ex
@@ -153,15 +153,24 @@ defmodule Pillar.TypeConvert.ToElixir do
       |> String.trim_trailing(")")
       |> String.split([", "])
 
-    Enum.zip(key_types, values)
-    |> Enum.map(fn
-      {key_type, {_key, value}} ->
-        [_key, type] = String.split(key_type)
-        convert(type, value)
+    acc = %{res: [], type: nil}
 
-      {key_type, value} ->
-        convert(key_type, value)
+    Enum.zip(key_types, values)
+    |> Enum.reduce(acc, fn
+      {key_type, {_key, value}}, acc ->
+        [key, type] = String.split(key_type)
+        elem = {key, convert(type, value)}
+        res = [elem | acc.res]
+        %{res: res, type: :map}
+
+      {key_type, value}, acc ->
+        res = [convert(key_type, value) | acc.res]
+        %{res: res, type: :list}
     end)
+    |> case do
+      %{type: :list, res: res} -> Enum.reverse(res)
+      %{type: :map, res: res} -> Map.new(res)
+    end
   end
 
   defp convert_datetime_with_timezone(value, time_zone) do

--- a/test/pillar_test.exs
+++ b/test/pillar_test.exs
@@ -331,6 +331,10 @@ defmodule PillarTest do
       sql = "SELECT (1, 2) as fst, (2, 3) as snd"
 
       assert {:ok, [%{"fst" => [1, 2], "snd" => [2, 3]}]} = Pillar.select(conn, sql)
+
+      sql = "SELECT (now(), '1') as fst"
+
+      assert {:ok, [%{"fst" => [%DateTime{}, "1"]}]} = Pillar.select(conn, sql)
     end
 
     test "Insert DateTime test", %{conn: conn} do

--- a/test/pillar_test.exs
+++ b/test/pillar_test.exs
@@ -327,6 +327,12 @@ defmodule PillarTest do
       assert {:ok, [%{"now()" => %DateTime{}}]} = Pillar.select(conn, sql)
     end
 
+    test "Tuple test", %{conn: conn} do
+      sql = "SELECT (1, 2) as fst, (2, 3) as snd"
+
+      assert {:ok, [%{"fst" => [1, 2], "snd" => [2, 3]}]} = Pillar.select(conn, sql)
+    end
+
     test "Insert DateTime test", %{conn: conn} do
       table_name = "datetime_test_#{@timestamp}"
 


### PR DESCRIPTION
The added test would fail on the master branch with the following traceback:

```bash
  1) test data types tests Tuple test (PillarTest)
     test/pillar_test.exs:330
     ** (FunctionClauseError) no function clause matching in anonymous fn/2 in Pillar.TypeConvert.ToElixir.convert/2

     The following arguments were given to anonymous fn/2 in Pillar.TypeConvert.ToElixir.convert/2:

         # 1
         {"UInt8", 1}

         # 2
         %{}

     code: assert {:ok, [%{"fst" => [1, 2], "snd" => [2, 3]}]} = Pillar.select(conn, sql)
     stacktrace:
       (pillar 0.35.0) lib/pillar/type_convert/to_elixir.ex:156: anonymous fn/2 in Pillar.TypeConvert.ToElixir.convert/2
       (elixir 1.14.3) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
       (pillar 0.35.0) lib/pillar/response_parser.ex:52: anonymous fn/2 in Pillar.ResponseParser.convert_row/2
       (elixir 1.14.3) lib/enum.ex:1662: anonymous fn/3 in Enum.map/2
       (stdlib 4.2) maps.erl:411: :maps.fold_1/3
       (elixir 1.14.3) lib/enum.ex:2480: Enum.map/2
       (pillar 0.35.0) lib/pillar/response_parser.ex:51: Pillar.ResponseParser.convert_row/2
       (elixir 1.14.3) lib/enum.ex:1658: Enum."-map/2-lists^map/1-0-"/2
       (pillar 0.35.0) lib/pillar/response_parser.ex:17: Pillar.ResponseParser.parse/1
       test/pillar_test.exs:333: (test)
```

I am not sure why it was accumulating the tuple key types in an map instead of a list, that seemed like a bug to me. Because given the tuple `(1,2)` and using the key types as the key in the map both would be having the same key `UInt8' and hence would override each other. 

So I replace it and used a list instead. 