### PR TITLE
FIX: Decimal insert from JSON

### DIFF
--- a/lib/pillar.ex
+++ b/lib/pillar.ex
@@ -5,6 +5,7 @@ defmodule Pillar do
   alias Pillar.HttpClient
   alias Pillar.QueryBuilder
   alias Pillar.ResponseParser
+  alias Pillar.Util
 
   @default_timeout_ms 5_000
 
@@ -13,12 +14,20 @@ defmodule Pillar do
     execute_sql(connection, final_sql, options)
   end
 
-  def insert_to_table(%Connection{} = connection, table_name, record_or_records, options \\ %{})
+  def insert_to_table(
+        %Connection{version: version} = connection,
+        table_name,
+        record_or_records,
+        options \\ %{}
+      )
       when is_binary(table_name) do
-    final_sql = QueryBuilder.insert_to_table(table_name, record_or_records)
+    query_options = Map.get(options, :query_options, %{})
+
+    final_sql =
+      QueryBuilder.insert_to_table(table_name, record_or_records, version, query_options)
 
     options =
-      if has_input_format_json_read_numbers_as_strings?(connection.version) do
+      if Util.has_input_format_json_read_numbers_as_strings?(version) do
         Map.put(options, :input_format_json_read_numbers_as_strings, true)
       else
         options
@@ -44,14 +53,6 @@ defmodule Pillar do
     |> Connection.url_from_connection(options)
     |> HttpClient.post(final_sql, timeout: timeout)
     |> ResponseParser.parse()
-  end
-
-  defp has_input_format_json_read_numbers_as_strings?(version) do
-    cond do
-      is_nil(version) -> false
-      Version.compare(version, "23.0.0") != :lt -> true
-      :else -> false
-    end
   end
 
   defmacro __using__(options) do

--- a/lib/pillar/query_builder.ex
+++ b/lib/pillar/query_builder.ex
@@ -18,14 +18,21 @@ defmodule Pillar.QueryBuilder do
     end
   end
 
-  def insert_to_table(table_name, record) when is_map(record) do
-    converted_value = convert_values_to_clickhouse_for_json_insert(record)
+  def insert_to_table(table_name, records, db_version \\ nil, query_options \\ %{})
+
+  def insert_to_table(table_name, record, db_version, query_options) when is_map(record) do
+    converted_value =
+      convert_values_to_clickhouse_for_json_insert(record, db_version, query_options)
 
     generate_json_insert_query(table_name, List.wrap(converted_value))
   end
 
-  def insert_to_table(table_name, records) when is_list(records) do
-    converted_values = Enum.map(records, &convert_values_to_clickhouse_for_json_insert/1)
+  def insert_to_table(table_name, records, db_version, query_options) when is_list(records) do
+    converted_values =
+      Enum.map(
+        records,
+        &convert_values_to_clickhouse_for_json_insert(&1, db_version, query_options)
+      )
 
     generate_json_insert_query(table_name, converted_values)
   end
@@ -41,11 +48,11 @@ defmodule Pillar.QueryBuilder do
     Enum.join(sql_strings, "\n")
   end
 
-  defp convert_values_to_clickhouse_for_json_insert(map) do
+  defp convert_values_to_clickhouse_for_json_insert(map, db_version, query_options) do
     map
     |> Enum.reject(fn {_key, value} -> is_nil(value) end)
     |> Enum.map(fn {key, value} ->
-      {key, ToClickhouseJson.convert(value)}
+      {key, ToClickhouseJson.convert(value, db_version, query_options)}
     end)
     |> Map.new()
   end

--- a/lib/pillar/type_convert/to_clickhouse_json.ex
+++ b/lib/pillar/type_convert/to_clickhouse_json.ex
@@ -1,4 +1,6 @@
 defmodule Pillar.TypeConvert.ToClickhouseJson do
+  require Decimal
+
   @moduledoc false
   def convert(param) when is_list(param) do
     if !Enum.empty?(param) && Keyword.keyword?(param) do
@@ -22,6 +24,10 @@ defmodule Pillar.TypeConvert.ToClickhouseJson do
   end
 
   def convert(nil), do: nil
+
+  def convert(param) when Decimal.is_decimal(param) do
+    Decimal.to_float(param)
+  end
 
   def convert(param) when is_atom(param) do
     Atom.to_string(param)

--- a/lib/pillar/type_convert/to_clickhouse_json.ex
+++ b/lib/pillar/type_convert/to_clickhouse_json.ex
@@ -1,68 +1,85 @@
 defmodule Pillar.TypeConvert.ToClickhouseJson do
   require Decimal
 
+  alias Pillar.Util
+
+  def convert(param, db_version \\ nil, query_options \\ %{})
+
   @moduledoc false
-  def convert(param) when is_list(param) do
+  def convert(param, db_version, query_options) when is_list(param) do
     if !Enum.empty?(param) && Keyword.keyword?(param) do
       param
-      |> Enum.map(fn {k, v} -> {to_string(k), convert(v)} end)
+      |> Enum.map(fn
+        {k, d} -> {to_string(k), convert(d, db_version, query_options)}
+      end)
       |> Enum.into(%{})
     else
-      Enum.map(param, &convert/1)
+      Enum.map(param, fn d ->
+        convert(d, db_version, query_options)
+      end)
     end
   end
 
-  def convert(param) when is_integer(param) do
+  def convert(param, db_version, query_options) when Decimal.is_decimal(param) do
+    cond do
+      Util.has_input_format_json_read_numbers_as_strings?(db_version) ->
+        Decimal.to_string(param)
+
+      Map.get(query_options, :decimal_as_float) == true ->
+        Decimal.to_float(param)
+
+      :else ->
+        raise "Your clickhouse version #{db_version} does not support inserting decimals as strings. You can allow converting decimals to floats by passing the option `query_options: %{decimal_as_float: true}` to insert_to_table"
+    end
+  end
+
+  def convert(param, _, _) when is_integer(param) do
     Integer.to_string(param)
   end
 
-  def convert(param) when is_boolean(param) do
+  def convert(param, _, _) when is_boolean(param) do
     case param do
       true -> 1
       false -> 0
     end
   end
 
-  def convert(nil), do: nil
+  def convert(nil, _, _), do: nil
 
-  def convert(param) when Decimal.is_decimal(param) do
-    Decimal.to_string(param)
-  end
-
-  def convert(param) when is_atom(param) do
+  def convert(param, _, _) when is_atom(param) do
     Atom.to_string(param)
   end
 
-  def convert(param) when is_float(param) do
+  def convert(param, _, _) when is_float(param) do
     Float.to_string(param)
   end
 
-  def convert(%DateTime{} = datetime) do
+  def convert(%DateTime{} = datetime, _, _) do
     datetime
     |> DateTime.truncate(:second)
     |> DateTime.to_iso8601()
     |> String.replace("Z", "")
   end
 
-  def convert(%Date{} = date) do
+  def convert(%Date{} = date, _, _) do
     date
     |> Date.to_iso8601()
   end
 
-  def convert(param) when is_map(param) do
+  def convert(param, db_version, query_options) when is_map(param) do
     json = Jason.encode!(param)
-    convert(json)
+    convert(json, db_version, query_options)
   end
 
-  def convert(param) when is_binary(param) do
+  def convert(param, _, _) when is_binary(param) do
     param
   end
 
-  def convert({:json, param}) do
+  def convert({:json, param}, _, _) do
     param
   end
 
-  def convert(param) do
+  def convert(param, _, _) do
     param
   end
 end

--- a/lib/pillar/type_convert/to_clickhouse_json.ex
+++ b/lib/pillar/type_convert/to_clickhouse_json.ex
@@ -26,7 +26,7 @@ defmodule Pillar.TypeConvert.ToClickhouseJson do
   def convert(nil), do: nil
 
   def convert(param) when Decimal.is_decimal(param) do
-    Decimal.to_float(param)
+    Decimal.to_string(param)
   end
 
   def convert(param) when is_atom(param) do

--- a/lib/pillar/util.ex
+++ b/lib/pillar/util.ex
@@ -1,0 +1,9 @@
+defmodule Pillar.Util do
+  def has_input_format_json_read_numbers_as_strings?(%Version{} = version) do
+    cond do
+      is_nil(version) -> false
+      Version.compare(version, "23.0.0") != :lt -> true
+      :else -> false
+    end
+  end
+end

--- a/test/pillar/connection_test.exs
+++ b/test/pillar/connection_test.exs
@@ -10,8 +10,9 @@ defmodule Pillar.ConnectionTest do
              user: "user",
              password: "password",
              port: 8123,
-             max_query_size: 1024
-           } ==
+             max_query_size: 1024,
+             version: _
+           } =
              Connection.new(
                "https://user:password@localhost:8123/some_database?max_query_size=1024"
              )
@@ -24,8 +25,9 @@ defmodule Pillar.ConnectionTest do
              scheme: "http",
              user: "alice",
              password: nil,
-             port: 8123
-           } == Connection.new("http://alice@localhost:8123")
+             port: 8123,
+             version: _
+           } = Connection.new("http://alice@localhost:8123")
   end
 
   test "#new - minimum required params" do
@@ -35,8 +37,9 @@ defmodule Pillar.ConnectionTest do
              scheme: "http",
              user: nil,
              password: nil,
-             port: 8123
-           } == Connection.new("http://localhost:8123")
+             port: 8123,
+             version: _
+           } = Connection.new("http://localhost:8123")
   end
 
   describe "#url_from_connection" do

--- a/test/pillar/query_builder_test.exs
+++ b/test/pillar/query_builder_test.exs
@@ -65,7 +65,7 @@ defmodule Pillar.QueryBuilderTest do
                "FORMAT JSONEachRow",
                "{\"field_1\":\"1\",\"field_2\":\"2\",\"field_3\":\"3\"} {\"field_2\":\"2\",\"field_3\":\"4\"} {\"field_1\":\"1\"} {\"field_2\":\"2\"} {\"field_3\":\"4\"} {}"
              ] ==
-               String.split(QueryBuilder.insert_to_table(table_name, values), "\n")
+               String.split(QueryBuilder.insert_to_table(table_name, values, nil), "\n")
     end
   end
 end

--- a/test/pillar_test.exs
+++ b/test/pillar_test.exs
@@ -693,6 +693,26 @@ defmodule PillarTest do
                Pillar.select(conn, "select * from #{table_name}")
     end
 
+    test "insert keyword as decimal", %{conn: conn} do
+      table_name = "to_table_inserts_decimal_#{@timestamp}"
+
+      create_table_sql = """
+        CREATE TABLE IF NOT EXISTS #{table_name} (
+          field1 Decimal32(4),
+        ) ENGINE = Memory
+      """
+
+      assert {:ok, ""} = Pillar.query(conn, create_table_sql)
+
+      record = %{
+        "field1" => Decimal.new(1)
+      }
+
+      assert {:ok, ""} = Pillar.insert_to_table(conn, table_name, [record])
+
+      assert {:ok, [^record]} = Pillar.select(conn, "select * from #{table_name}")
+    end
+
     test "insert keyword as map", %{conn: conn} do
       %{"major" => major} = version(conn)
 


### PR DESCRIPTION
@sofakingworld 

It seems we cannot insert Decimal values anymore. Is there any setting in clickhouse which can be activated so that decimal values can be inserted as string? 

I don't really like casting decimal values to float. 

```
mpro-2.local :) create table foobar ( field4 Decimal32(4)) engine = Memory;

CREATE TABLE foobar
(
    `field4` Decimal32(4)
)
ENGINE = Memory

Query id: a2f8142f-07a6-4785-a214-bfec6221716f

Ok.

0 rows in set. Elapsed: 0.010 sec.

mpro-2.local :) insert into foobar FORMAT JSONEachRow {"field4": "1"}

INSERT INTO foobar FORMAT JSONEachRow

Query id: e29f0614-b7f4-4159-af15-e7ab97a6b332

Ok.
Exception on client:
Code: 27. DB::ParsingException: Cannot parse input: expected ',' before: '"1"}': While executing ParallelParsingBlockInputFormat: data for INSERT was parsed from query: (at row 1)
. (CANNOT_PARSE_INPUT_ASSERTION_FAILED)

mpro-2.local :) insert into foobar FORMAT JSONEachRow {"field4": 1}

INSERT INTO foobar FORMAT JSONEachRow

Query id: 9f40dd14-2e4a-4c21-8bd0-515672e10e59

Ok.

1 row in set. Elapsed: 0.003 sec.

mpro-2.local :) insert into foobar FORMAT JSONEachRow {"field4": 1.0}

INSERT INTO foobar FORMAT JSONEachRow

Query id: 80793946-c2c1-4a2f-8c97-691c6d3d2414

Ok.

1 row in set. Elapsed: 0.003 sec.

mpro-2.local :) insert into foobar FORMAT JSONEachRow {"field4": "1"}

INSERT INTO foobar FORMAT JSONEachRow

Query id: a4552108-677b-47da-bcab-bc9c1cb67583

Ok.
Exception on client:
Code: 27. DB::ParsingException: Cannot parse input: expected ',' before: '"1"}': While executing ParallelParsingBlockInputFormat: data for INSERT was parsed from query: (at row 1)
. (CANNOT_PARSE_INPUT_ASSERTION_FAILED)

```